### PR TITLE
Update crawler.py

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -1,25 +1,28 @@
 # Native lib
 import os
-import re
-import urllib
-import urllib2
+import sys
+from urllib.request import urlopen
+from urllib.error import URLError
 
 # Third party lib
 from bs4 import BeautifulSoup
 
 # Read the html text
 url = 'http://www.pokemoncenter.com/apparel/t-shirts#facet:&productBeginIndex:0&facetLimit:&orderBy:5&pageView:grid&minPrice:&maxPrice:&pageSize:&'
-request = urllib2.Request(url)
-response = urllib2.urlopen(request)
-html = response.read()
-response.close()
+
+# Exception handling of URLError
+try:
+  html = urlopen(url)
+except URLError as e:
+  print('The page is not found')
+  sys.exit()
 
 # Massage the html text
-soup = BeautifulSoup(html, 'html.parser')
+soup = BeautifulSoup(html, 'lxml')
 product_names_arr = soup.find_all('div', class_ = 'product_name')
 product_prices_arr = soup.find_all('div', class_ = 'product_price')
 arr_length = len(product_prices_arr)
-for i in xrange(0, arr_length - 1):
+for i in range(0, arr_length - 1):
   product_name = product_names_arr[i].find_all(text = True)
   product_price = product_prices_arr[i].find_all(text = True)
 


### PR DESCRIPTION
I do some modifications on crawler.py. Regardless the syntax between Python 2.x and Python 3.x, the main change are below:
1. Added a exception handling of URLError
2. Deleted some redundant rows, like simplifying the data fetching using urllib module.

For 2nd point, I am wondering why there are lot of codes pass the "http.client.HTTPResponse" object, which is the result of urllib.urlopen(), to .read(), before passing them to the BeautifulSoup(). I think it may be a kind of legacy from the very beginning BeautifulSoup() which is not as good as the BeautifulSoup() in BS4. Right now, BeautifulSoup() function can handle the http response object for the URL requested smoothly.

Another choice is using .read() for a plain text webpage with regular expression to obtain the useful data. This can be done without using BeautifulSoup().
